### PR TITLE
Add removal of ExampleTest.php to CI Script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - composer self-update
   - composer create-project laravel/laravel
   - cd ./laravel
-  - rm tests/Unit/ExampleTest.php
+  - rm tests/Feature/ExampleTest.php
   - composer require tendoo/cms:dev-master
   - composer update
   - php artisan tendoo:publish

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_install:
   - composer self-update
   - composer create-project laravel/laravel
   - cd ./laravel
+  - rm tests/Unit/ExampleTest.php
   - composer require tendoo/cms:dev-master
   - composer update
   - php artisan tendoo:publish


### PR DESCRIPTION
Travis CI test is failing based on laravel default unit test.

I've added a line in the CI script to remove this.